### PR TITLE
Provide alternative link for port 8080

### DIFF
--- a/cloudflared.log
+++ b/cloudflared.log
@@ -1,0 +1,21 @@
+{"level":"info","time":"2025-09-13T13:23:08Z","message":"Thank you for trying Cloudflare Tunnel. Doing so, without a Cloudflare account, is a quick way to experiment and try it out. However, be aware that these account-less Tunnels have no uptime guarantee, are subject to the Cloudflare Online Services Terms of Use (https://www.cloudflare.com/website-terms/), and Cloudflare reserves the right to investigate your use of Tunnels for violations of such terms. If you intend to use Tunnels in production you should use a pre-created named tunnel by following: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps"}
+{"level":"info","time":"2025-09-13T13:23:08Z","message":"Requesting new quick Tunnel on trycloudflare.com..."}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"+--------------------------------------------------------------------------------------------+"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"|  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"|  https://top-evaluate-wanted-pursuit.trycloudflare.com                                     |"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"+--------------------------------------------------------------------------------------------+"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Cannot determine default configuration path. No file [config.yml config.yaml] in [~/.cloudflared ~/.cloudflare-warp ~/cloudflare-warp /etc/cloudflared /usr/local/etc/cloudflared]"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Version 2025.8.1 (Checksum a66353004197ee4c1fcb68549203824882bba62378ad4d00d234bdb8251f1114)"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"GOOS: linux, GOVersion: go1.24.4, GoArch: amd64"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Settings: map[edge-ip-version:auto ha-connections:1 logfile:/workspace/cloudflared.log loglevel:info metrics:localhost:0 no-autoupdate:true p:http2 protocol:http2 url:http://localhost:8080]"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Generated Connector ID: cb92c114-01f9-4feb-b3d1-3d86e1aef7c7"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Initial protocol http2"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"ICMP proxy will use 172.30.0.2 as source for IPv4"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"ICMP proxy will use fe80::802b:38ff:fe3d:bcd0 in zone eth0 as source for IPv6"}
+{"level":"warn","error":"Group ID 1000 is not between ping group 1 to 0","time":"2025-09-13T13:23:11Z","message":"The user running cloudflared process has a GID (group ID) that is not within ping_group_range. You might need to add that user to a group within that range, or instead update the range to encompass a group the user is already in by modifying /proc/sys/net/ipv4/ping_group_range. Otherwise cloudflared will not be able to ping this network"}
+{"level":"warn","error":"cannot create ICMPv4 proxy: Group ID 1000 is not between ping group 1 to 0 nor ICMPv6 proxy: socket: permission denied","time":"2025-09-13T13:23:11Z","message":"ICMP proxy feature is disabled"}
+{"level":"error","originCertPath":"","time":"2025-09-13T13:23:11Z","message":"Cannot determine default origin certificate path. No file cert.pem in [~/.cloudflared ~/.cloudflare-warp ~/cloudflare-warp /etc/cloudflared /usr/local/etc/cloudflared]. You need to specify the origin certificate path by specifying the origincert option in the configuration file, or set TUNNEL_ORIGIN_CERT environment variable"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"ICMP proxy will use 172.30.0.2 as source for IPv4"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"ICMP proxy will use fe80::802b:38ff:fe3d:bcd0 in zone eth0 as source for IPv6"}
+{"level":"info","time":"2025-09-13T13:23:11Z","message":"Starting metrics server on 127.0.0.1:20241/metrics"}
+{"level":"info","event":0,"connection":"710052ff-0403-4157-806c-15a6e5cf328c","connIndex":0,"location":"ord12","ip":"198.41.200.233","protocol":"http2","time":"2025-09-13T13:23:12Z","message":"Registered tunnel connection"}


### PR DESCRIPTION
Create a Cloudflare tunnel to expose the local 8080 port publicly, providing an accessible link for the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-f68577ef-1f12-4fac-9bef-acb5963539e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f68577ef-1f12-4fac-9bef-acb5963539e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

